### PR TITLE
wrapping Environment values in " "

### DIFF
--- a/systemd/starlink-influx2.service
+++ b/systemd/starlink-influx2.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 Type=simple
 WorkingDirectory=/opt/starlink-grpc-tools/
-Environment=INFLUXDB_URL=http://localhost:8086 INFLUXDB_TOKEN=<changeme> INFLUXDB_Bucket=<changeme> INFLUXDB_ORG=<changeme> INFLUXDB_SSL=false
+Environment="INFLUXDB_URL=http://localhost:8086 INFLUXDB_TOKEN=<changeme> INFLUXDB_Bucket=<changeme> INFLUXDB_ORG=<changeme> INFLUXDB_SSL=false"
 ExecStart=/opt/starlink-grpc-tools/venv/bin/python3 dish_grpc_influx2.py -t 10 status alert_detail
 
 [Install]


### PR DESCRIPTION
By wrapping the Environment variables in " " we can avoid having this system file break if/when an influx token or org include = signs (as in my case). See: https://github.com/sparky8512/starlink-grpc-tools/issues/68